### PR TITLE
fixed binary output path

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,7 +3,7 @@ srcPath="cmd"
 pkgFile="main.go"
 outputPath="build"
 app="gqlgen-api-starter"
-output="$outputPath"
+output="$outputPath/$app"
 src="$srcPath/$app/$pkgFile"
 
 printf "\nBuilding: $app\n"


### PR DESCRIPTION
Previous output path was not creating a build folder thus not creating the binary file upon build.